### PR TITLE
Fix grid boundaries for player 2

### DIFF
--- a/CodeBenders/Assets/Battle.cs
+++ b/CodeBenders/Assets/Battle.cs
@@ -23,7 +23,7 @@ public class Battle : MonoBehaviour
         buildingBlocks = FindObjectsOfType(typeof(Rigidbody2D)) as Rigidbody2D[];
         foreach (Rigidbody2D buildingBlock in buildingBlocks)
         {
-            if (buildingBlock.tag == "BuildingBlock")
+            if (buildingBlock.tag.Contains("BuildingBlock"))
             {
                 buildingBlock.constraints = RigidbodyConstraints2D.None;
             }

--- a/CodeBenders/Assets/Scenes/MainScene.unity
+++ b/CodeBenders/Assets/Scenes/MainScene.unity
@@ -856,7 +856,7 @@ GameObject:
   - component: {fileID: 143510623}
   m_Layer: 0
   m_Name: target3 II
-  m_TagString: Enemy
+  m_TagString: EnemyP2
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1653,7 +1653,7 @@ GameObject:
   - component: {fileID: 268428294}
   m_Layer: 0
   m_Name: Vertical-3 II
-  m_TagString: BuildingBlock
+  m_TagString: BuildingBlockP2
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -4546,7 +4546,7 @@ GameObject:
   - component: {fileID: 639479583}
   m_Layer: 0
   m_Name: target2 II
-  m_TagString: Enemy
+  m_TagString: EnemyP2
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -6732,7 +6732,8 @@ MonoBehaviour:
   Battle: {fileID: 1174198896}
   buildingBlocks: []
   moveCam: {fileID: 774410621}
-  enemies: []
+  enemiesP1: []
+  enemiesP2: []
 --- !u!4 &902626941
 Transform:
   m_ObjectHideFlags: 0
@@ -12839,7 +12840,7 @@ GameObject:
   - component: {fileID: 1577514735}
   m_Layer: 0
   m_Name: Vertical-1 II
-  m_TagString: BuildingBlock
+  m_TagString: BuildingBlockP2
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -13772,7 +13773,7 @@ GameObject:
   - component: {fileID: 1676206524}
   m_Layer: 0
   m_Name: Horizontal II
-  m_TagString: BuildingBlock
+  m_TagString: BuildingBlockP2
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -15437,7 +15438,7 @@ GameObject:
   - component: {fileID: 1898303124}
   m_Layer: 0
   m_Name: Vertical-2 II
-  m_TagString: BuildingBlock
+  m_TagString: BuildingBlockP2
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -18255,7 +18256,7 @@ GameObject:
   - component: {fileID: 2136929561}
   m_Layer: 0
   m_Name: target1 II
-  m_TagString: Enemy
+  m_TagString: EnemyP2
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/CodeBenders/Assets/Scripts/DragDrop.cs
+++ b/CodeBenders/Assets/Scripts/DragDrop.cs
@@ -32,14 +32,28 @@ public class DragDrop : MonoBehaviour
             {
                 transform.position = new Vector2(Mathf.RoundToInt(transform.position.x/gridSize)*gridSize, Mathf.RoundToInt(transform.position.y/gridSize)*gridSize);
             }
-            if ((transform.position.x - tileWidth/2)<-17.15)
-              transform.position = new Vector2(-17.15f+tileWidth/2, Mathf.RoundToInt(transform.position.y));
-            if ((transform.position.y - tileHeight/2) < 1.85)
-              transform.position = new Vector2(Mathf.RoundToInt(transform.position.x), 1.85f+tileHeight/2);
-            if ((transform.position.y+tileHeight/2) > 9.85)
-              transform.position = new Vector2(Mathf.RoundToInt(transform.position.x), 9.85f-tileHeight/2);
-            if ((transform.position.x+tileWidth/2) > -8.15)
-              transform.position = new Vector2(-8.15f-tileWidth/2, Mathf.RoundToInt(transform.position.y));
+            if(gameObject.tag == "BuildingBlock" || gameObject.tag == "Enemy")
+            {
+              if ((transform.position.x - tileWidth/2)<-17.15)
+                transform.position = new Vector2(-17.15f+tileWidth/2, Mathf.RoundToInt(transform.position.y));
+              if ((transform.position.y - tileHeight/2) < 1.85)
+                transform.position = new Vector2(Mathf.RoundToInt(transform.position.x), 1.85f+tileHeight/2);
+              if ((transform.position.y+tileHeight/2) > 9.85)
+                transform.position = new Vector2(Mathf.RoundToInt(transform.position.x), 9.85f-tileHeight/2);
+              if ((transform.position.x+tileWidth/2) > -8.15)
+                transform.position = new Vector2(-8.15f-tileWidth/2, Mathf.RoundToInt(transform.position.y));
+            }
+            else
+            {
+              if ((transform.position.x - tileWidth/2)<11.4)
+                transform.position = new Vector2(11.4f+tileWidth/2, Mathf.RoundToInt(transform.position.y));
+              if ((transform.position.y - tileHeight/2) < 1.85)
+                transform.position = new Vector2(Mathf.RoundToInt(transform.position.x), 1.85f+tileHeight/2);
+              if ((transform.position.y+tileHeight/2) > 9.85)
+                transform.position = new Vector2(Mathf.RoundToInt(transform.position.x), 9.85f-tileHeight/2);
+              if ((transform.position.x+tileWidth/2) > 20.4)
+                transform.position = new Vector2(20.4f-tileWidth/2, Mathf.RoundToInt(transform.position.y));
+            }
         }
     }
 

--- a/CodeBenders/Assets/tryButton.cs
+++ b/CodeBenders/Assets/tryButton.cs
@@ -16,7 +16,8 @@ public class tryButton : MonoBehaviour
     public Button Battle;
     public Rigidbody2D[] buildingBlocks;
     public MoveCam moveCam;
-    public GameObject[] enemies;
+    public GameObject[] enemiesP1;
+    public GameObject[] enemiesP2;
 
     void Start()
     {
@@ -31,19 +32,28 @@ public class tryButton : MonoBehaviour
         buildingBlocks = FindObjectsOfType(typeof(Rigidbody2D)) as Rigidbody2D[];
         foreach (Rigidbody2D buildingBlock in buildingBlocks)
         {
-            if (buildingBlock.tag == "BuildingBlock")
+            if (buildingBlock.tag.Contains("BuildingBlock"))
             {
                 buildingBlock.constraints = RigidbodyConstraints2D.None;
             }
         }
-        enemies = GameObject.FindGameObjectsWithTag("Enemy");
-        foreach(GameObject enemy in enemies)
+        // enable enemies for player 1
+        enemiesP1 = GameObject.FindGameObjectsWithTag("Enemy");
+        foreach(GameObject enemy in enemiesP1)
         {
             enemy.GetComponent<Enemy>().enabled = true;
             enemy.GetComponent<DragDrop>().enabled = false;
 
         }
+        // enable enemies for player 2
+        // **should be moved till after 2nd player build phase**
+        enemiesP2 = GameObject.FindGameObjectsWithTag("EnemyP2");
+        foreach(GameObject enemy in enemiesP2)
+        {
+            enemy.GetComponent<Enemy>().enabled = true;
+            enemy.GetComponent<DragDrop>().enabled = false;
+        }
         moveCam.ExitBuildMode();
     }
-    
+
 }

--- a/CodeBenders/ProjectSettings/TagManager.asset
+++ b/CodeBenders/ProjectSettings/TagManager.asset
@@ -6,6 +6,8 @@ TagManager:
   tags:
   - BuildingBlock
   - Enemy
+  - BuildingBlockP2
+  - EnemyP2
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Previously, when you dragged player 2's building blocks or "cargo" it would instantly shift to player 1's grid due to DragDrop recognizing it was out of bounds of player 1's grid.

The main objective of this PR was to confine player 2's objects (enemies and building blocks) in its respective grid.

Summary of changes:

- New tags for player 2's objects

- Refactor calling objects by tag (check if string contains "BuildingBlock" rather than == "BuildingBlock")

- Player 2's objects are confined by grid bounds 