### PR TITLE
Variable Target Health

### DIFF
--- a/CodeBenders/Assets/Scripts/Enemy.cs
+++ b/CodeBenders/Assets/Scripts/Enemy.cs
@@ -6,7 +6,7 @@
 public class Enemy : MonoBehaviour
 {
     /// <summary>
-    /// How much damage a target can withstand.
+    /// How much damage can a target withstand.
     /// </summary>
     public float health = 2f;
 
@@ -14,6 +14,8 @@ public class Enemy : MonoBehaviour
     private void OnCollisionEnter2D(Collision2D colInfo)
     {
         // if the collision is more than what the target can withstand then it gets destroyed
-        if (colInfo.relativeVelocity.magnitude > health) Destroy(gameObject);
+        if (health.CompareTo(colInfo.relativeVelocity.magnitude) <= 0) Destroy(gameObject);
+        // else its health gets decreased
+        else health -= colInfo.relativeVelocity.magnitude;
     }
 }


### PR DESCRIPTION
This PR contains everything from #36 and the variable target health feature:
- If a collision is more than the health of a target, then it gets destroyed (original behavior)
- Otherwise, its health gets decreased by the amount of the collision (added behavior)

This PR can be either directly merged (bypassing #36 entirely) or merged after midterm (but merge #36 first since it contains critical bugfixes) if more testing and discussion on this feature is desired.