### PR TITLE
Enhancements to the Slingshots and Projectiles

### DIFF
--- a/CodeBenders/Assets/Scenes/MainScene.unity
+++ b/CodeBenders/Assets/Scenes/MainScene.unity
@@ -10766,6 +10766,7 @@ MonoBehaviour:
   projectileTag: ProjectileP1
   projectileSprite: {fileID: 21300000, guid: 31ef2b54bedf69746b832114ff05fbf7, type: 3}
   projectileSortingOrder: 2
+  pojectileScaleFactor: 2.45
   projectColliderRadius: 0.305
   projectileMass: 2
   projectileLinearDrag: 0
@@ -13436,6 +13437,7 @@ GameObject:
   - component: {fileID: 1515269862}
   - component: {fileID: 1515269865}
   - component: {fileID: 1515269864}
+  - component: {fileID: 1515269866}
   - component: {fileID: 1515269863}
   m_Layer: 5
   m_Name: PlayerTurn
@@ -13519,6 +13521,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1515269861}
   m_CullTransparentMesh: 0
+--- !u!114 &1515269866
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1515269861}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2de3d0e4f4d0b0145b3a152b5fdd20d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1525766899
 GameObject:
   m_ObjectHideFlags: 0
@@ -18877,6 +18891,7 @@ MonoBehaviour:
   projectileTag: ProjectileP2
   projectileSprite: {fileID: 21300000, guid: 31ef2b54bedf69746b832114ff05fbf7, type: 3}
   projectileSortingOrder: 2
+  pojectileScaleFactor: 2.45
   projectColliderRadius: 0.305
   projectileMass: 2
   projectileLinearDrag: 0

--- a/CodeBenders/Assets/Scripts/ControlButton.cs
+++ b/CodeBenders/Assets/Scripts/ControlButton.cs
@@ -59,6 +59,7 @@ public class ControlButton : MonoBehaviour
                 }
                                 
                 // enable slingshot reload for player 1
+                // only player 1 is enabled because player 1 goes first
                 GameObject.FindWithTag("SlingshotP1").SendMessage("EnableSlingshotReloading");
                 
                 // enable enemies for player 2
@@ -74,10 +75,7 @@ public class ControlButton : MonoBehaviour
                 {
                     block.GetComponent<DragDrop>().enabled = false;
                 }
-                
-                // enable slingshot reload for player 2
-                GameObject.FindWithTag("SlingshotP2").SendMessage("EnableSlingshotReloading");
-                
+
                 moveCam.SwitchCameraMode(0);  
                 break;
         }

--- a/CodeBenders/Assets/Scripts/EnableSlingshotByPlayerTurn.cs
+++ b/CodeBenders/Assets/Scripts/EnableSlingshotByPlayerTurn.cs
@@ -1,0 +1,24 @@
+﻿using UnityEngine;
+
+/// <summary>
+/// Enable the slingshot for a single player in a given turn.
+/// </summary>
+public class EnableSlingshotByPlayerTurn : MonoBehaviour
+{
+    /// <summary>
+    /// Enable the slingshot for a given player.
+    /// </summary>
+    /// <param name="player">The player to enable the slingshot for.</param>
+    public void EnableSlingshotForPlayer(PlayersEnum player)
+    {
+        switch (player)
+        {
+            case PlayersEnum.PlayerOne:
+                GameObject.FindWithTag("SlingshotP1").SendMessage("EnableSlingshotReloading");
+                break;
+            case PlayersEnum.PlayerTwo:
+                GameObject.FindWithTag("SlingshotP2").SendMessage("EnableSlingshotReloading");
+                break;
+        }
+    }
+}

--- a/CodeBenders/Assets/Scripts/EnableSlingshotByPlayerTurn.cs.meta
+++ b/CodeBenders/Assets/Scripts/EnableSlingshotByPlayerTurn.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2de3d0e4f4d0b0145b3a152b5fdd20d3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CodeBenders/Assets/Scripts/Projectile.cs
+++ b/CodeBenders/Assets/Scripts/Projectile.cs
@@ -42,15 +42,17 @@ public class Projectile : MonoBehaviour
         // update the telemetry counter
         GameObject.Find("Telemetry").SendMessage(
             gameObject.tag.Equals("ProjectileP1") ? "PlayerOneFired" : "PlayerTwoFired");
-        
-        // start the slingshot reload coroutine
-        StartCoroutine(slingshot.gameObject.GetComponent<SlingshotLoader>().ReloadProjectileCoroutine());
 
         // wait before further actions such as self-destruction
         yield return new WaitForSeconds(SpringJointPostDisableDelay);
 
-        //Change player name on display
+        // change player name on display
         GameObject.FindWithTag("PlayerTurn").SendMessage("changePlayer", gameObject);
+        
+        // enable the slingshot for the other side
+        GameObject.Find("PlayerTurn").SendMessage("EnableSlingshotForPlayer",
+            gameObject.tag.Equals("ProjectileP1") ? PlayersEnum.PlayerTwo : PlayersEnum.PlayerOne);
+        
         Destroy(gameObject);
     }
 

--- a/CodeBenders/Assets/Scripts/ProjectileGenerator.cs
+++ b/CodeBenders/Assets/Scripts/ProjectileGenerator.cs
@@ -10,12 +10,12 @@ public class ProjectileGenerator : MonoBehaviour
     /// Whether we allow reloading.
     /// </summary>
     public bool allowReloading;
-
+    
     /// <summary>
     /// Whether a new projectile is needed.
     /// </summary>
     public bool newProjectileNeeded;
-
+    
     /// <summary>
     /// The tag that indicates which player the projectile belongs to.
     /// </summary>
@@ -32,30 +32,35 @@ public class ProjectileGenerator : MonoBehaviour
     public int projectileSortingOrder;
 
     /// <summary>
+    /// The scale factor of the generated projectile (greater than 0).
+    /// </summary>
+    public float pojectileScaleFactor;
+    
+    /// <summary>
     /// The collider radius of the generated projectile.
     /// </summary>
     public float projectColliderRadius;
-
+    
     /// <summary>
     /// The mass of the generated projectile.
     /// </summary>
     public float projectileMass;
-
+    
     /// <summary>
     /// The linear drag of the generated projectile.
     /// </summary>
     public float projectileLinearDrag;
-
+    
     /// <summary>
     /// The angular drag of the generated projectile.
     /// </summary>
     public float projectileAngularDrag;
-
+    
     /// <summary>
     /// The gravity scale of the generated projectile.
     /// </summary>
     public float projectileGravityScale;
-
+    
     // the slingshot loader component
     private SlingshotLoader _slingshotLoader;
 
@@ -64,6 +69,7 @@ public class ProjectileGenerator : MonoBehaviour
     /// </summary>
     /// <param name="sprite">The sprite to be used.</param>
     /// <param name="sortingOrder">The sorting or rendering order of the projectile.</param>
+    /// <param name="scaleFactor">The scale factor of the projectile (greater than 0).</param>
     /// <param name="radius">The collider radius of the projectile.</param>
     /// <param name="mass">The mass of the projectile.</param>
     /// <param name="linearDrag">The linear drag of the projectile.</param>
@@ -72,6 +78,7 @@ public class ProjectileGenerator : MonoBehaviour
     /// <returns>The game object corresponding to the generated projectile.</returns>
     public GameObject GenerateProjectile(Sprite sprite,
         int sortingOrder,
+        float scaleFactor,
         float radius,
         float mass,
         float linearDrag,
@@ -79,12 +86,12 @@ public class ProjectileGenerator : MonoBehaviour
         float gravityScale)
     {
         // include a GUID in the name so no name collision could be possible
-        var projectile = new GameObject($"Projectile ({Guid.NewGuid()})",
+        var projectile = new GameObject($"Projectile ({Guid.NewGuid()})", 
             new []{typeof(CircleCollider2D), typeof(SpriteRenderer), typeof(Rigidbody2D)});
         // tag the projectile
         projectile.tag = projectileTag;
-        //scale the projectile
-        projectile.transform.localScale = new Vector3(2.45f, 2.45f, 2.45f);
+        // set the scale factor of the projectile
+        projectile.transform.localScale = new Vector3(scaleFactor, scaleFactor, scaleFactor);
         // place the projectile in the same hierarchy as the slingshot
         projectile.transform.parent = transform.parent;
 
@@ -100,7 +107,7 @@ public class ProjectileGenerator : MonoBehaviour
 
         return projectile;
     }
-
+    
     //called before the first frame update
     private void Start() => _slingshotLoader = GetComponent<SlingshotLoader>();
 
@@ -108,11 +115,11 @@ public class ProjectileGenerator : MonoBehaviour
     private void Update()
     {
         if (!allowReloading || !newProjectileNeeded) return; // short circuit for not needing a new projectile
-
+        
         // currently this script handles invocation and reloading, but this should be moved out to somewhere else
         _slingshotLoader.LoadProjectile(
             GenerateProjectile(
-                projectileSprite, projectileSortingOrder, projectColliderRadius, projectileMass,
+                projectileSprite, projectileSortingOrder, pojectileScaleFactor, projectColliderRadius, projectileMass,
                 projectileLinearDrag, projectileAngularDrag, projectileGravityScale));
         // that the projectile has been reloaded and a new one is no longer needed
         newProjectileNeeded = false;

--- a/CodeBenders/Assets/Scripts/SlingshotLoader.cs
+++ b/CodeBenders/Assets/Scripts/SlingshotLoader.cs
@@ -49,6 +49,9 @@ public class SlingshotLoader : MonoBehaviour
         var projectileComponent = projectile.AddComponent<Projectile>();
         projectileComponent.allowFiring = true; // for now we always allow firing
         projectileComponent.slingshot = _slingshotBody;
+        
+        // disable reload after being loaded to prevent reloading during the other player's turn
+        GetComponent<ControlSlingshotFunctions>().DisableSlingshotReloading();
     }
 
     /// <summary>


### PR DESCRIPTION
- The slingshot will no longer auto-load immediately after firing, instead, it will only be reloaded the at the next turn of the given player (i.e. Player 1's slingshot will not be loaded during Player 2's turn)
  - This should also eliminate the problem of the projectile from one player hitting the to-be-fired projectile of another player and causing both to bounce, but this effect can still be implemented if desired
- The scale factor of the projectiles is now a configurable field in the ProjectileGenerator component, which potentially allows projectiles of different sizes to be easily configured